### PR TITLE
fix t.t. unit bug with words containing double t's

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,8 @@ function getUnit(input: string, language: string) {
   let symbolUnits = unit[3]
   let response = [] as string[];
   const [toTaste, match, extFlag] = toTasteRecognize(input, language)
-  if (toTaste) {
+  // If there is already a unit found for the ingredient, don't add toTaste. Fixes t.t. bug from words with two t's
+  if (toTaste && !unit) {
     if (extFlag) {
       response = [toTaste, toTaste, match];
     }


### PR DESCRIPTION
## Description
Fixes a bug where words with two t's together in the ingredient name (such as "butter") would cause the returned ingredient unit to be "t.t." instead of the expected unit. For example '1 cup butter' would return the unit as t.t. and the ingredient as 'buer'. The getUnit function was not checking whether a unit had already been found for the current ingredient and would always update the unit to 't.t.' if a 'toTaste' match was found.

## Changes Made
Updated the index.ts getUnit function to check whether a unit has already been found for the current ingredient before adding t.t. as the unit.